### PR TITLE
Adapt Dockerfile with the latest release of Asterisk 13.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM respoke/pjsip:latest
+FROM debian:jessie
 MAINTAINER Respoke <info@respoke.io>
 
 RUN useradd --system asterisk
@@ -30,7 +30,7 @@ RUN apt-get update -qq && \
     pip install j2cli && \
     apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
-ENV ASTERISK_VERSION=13.11.0
+ENV ASTERISK_VERSION=13.15.0
 COPY build-asterisk.sh /build-asterisk
 RUN /build-asterisk && rm -f /build-asterisk
 COPY asterisk-docker-entrypoint.sh /

--- a/build-asterisk.sh
+++ b/build-asterisk.sh
@@ -18,7 +18,7 @@ cd /usr/src/asterisk
 curl -vsL http://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-${ASTERISK_VERSION}.tar.gz |
     tar --strip-components 1 -xz
 
-./configure 
+./configure --with-pjproject-bundled
 make menuselect/menuselect menuselect-tree menuselect.makeopts
 
 # MOAR SOUNDS


### PR DESCRIPTION
Hi,

Because now pjsip is bundled with Asterisk, it isn't necessary to use respoke/pjsip.

Thanks for the merge.